### PR TITLE
Batch wage payments and production costs to reduce log clutter

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="100">
     <author>Ritter</author>
-    <version>1.0.0.2</version>
+    <version>1.0.1.0</version>
     <iconFilename>icon_TransactionLog.dds</iconFilename>
     <title>
         <en>Transaction log</en>

--- a/scripts/RmTransactionBatcher.lua
+++ b/scripts/RmTransactionBatcher.lua
@@ -6,7 +6,7 @@ local RmTransactionBatcher_mt = Class(RmTransactionBatcher)
 
 -- Constants
 RmTransactionBatcher.BATCH_DELAY_MS = 5000   -- 5 seconds batch collection window
-RmTransactionBatcher.MAX_BATCH_COUNT = 500   -- Maximum number of transactions in a single batch
+RmTransactionBatcher.MAX_BATCH_COUNT = 10000 -- Maximum number of transactions in a single batch
 RmTransactionBatcher.MAX_ACTIVE_BATCHES = 50 -- Maximum number of active batches, just to be safe
 
 -- Transaction statistics that should be batched (frequent small transactions)
@@ -23,6 +23,8 @@ RmTransactionBatcher.BATCHABLE_STATISTICS = {
     "soldProducts",       -- Products sold (e.g. eggs, wool)
     "soldWood",           -- Wood sold
     "vehicleRunningCost", -- Running costs for vehicles
+    "wagePayment",        -- Wage payments to workers
+    "productionCosts",    -- Production costs
 }
 
 -- Hash table for lookup performance
@@ -123,7 +125,7 @@ function RmTransactionBatcher.flushBatch(batchKey, logFunction)
     end
 
     RmUtils.logDebug("Flushing batch: " ..
-    batchKey .. " with " .. batch.count .. " transactions, total: " .. tostring(batch.totalAmount))
+        batchKey .. " with " .. batch.count .. " transactions, total: " .. tostring(batch.totalAmount))
 
     -- Create aggregated transaction with batch info in comment
     local batchComment = ""


### PR DESCRIPTION
This update batches wage payments and production costs to minimize the frequency of log entries, addressing the issue of excessive log clutter. The maximum batch size has been increased to accommodate more transactions without increasing memory usage. Fixes #7